### PR TITLE
Fixed two bugs in TrivialCompiler

### DIFF
--- a/src/conv/typeck.cpp
+++ b/src/conv/typeck.cpp
@@ -102,7 +102,7 @@ struct Env {
     if (d.has_init) {
       if (d.dims.empty() && d.init.val1) {  // 形如int x = 1
         ck_expr(d.init.val1);
-        if (d.is_const) {
+        if (d.is_const || d.is_glob) {
           eval(d.init.val1);
         }
         d.flatten_init.push_back(d.init.val1);

--- a/src/passes/ir/extract_stack_array.cpp
+++ b/src/passes/ir/extract_stack_array.cpp
@@ -1,5 +1,6 @@
 #include "extract_stack_array.hpp"
 
+#include <cstdlib>
 #include <unordered_set>
 #include <vector>
 
@@ -22,6 +23,7 @@ void extract_stack_array(IrProgram *p) {
         }
       }
     };
+    size_t sym_counter = 0;
     std::unordered_set<AllocaInst *> delete_list;
     // iterate through all instructions in a BB
     for (auto bb = f->bb.head; bb; bb = bb->next) {
@@ -80,8 +82,8 @@ void extract_stack_array(IrProgram *p) {
               for (int i = 0; i < size; ++i) {
                 init.push_back(buffer[i] == 0 ? &IntConst::ZERO : new IntConst{Expr::Tag::IntConst, buffer[i]});
               }
-              auto name =
-                  new std::string("__extracted_" + std::string(f->func->name) + "_" + std::string(alloc->sym->name));
+              auto name = new std::string("__extracted_" + std::string(f->func->name) + "_" +
+                                          std::string(alloc->sym->name) + "_" + std::to_string(sym_counter++));
               auto extract_array = "Extract local array " + std::string(alloc->sym->name) + " to global " + *name;
               dbg(extract_array);
               auto extracted_decl =


### PR DESCRIPTION
## Symbol Name Confliction (5717a8e)

TrivialCompiler will generate LLVM IR/assembly containing duplicate symbol names after compiling the following C code:

```c
int main() {
  int arr[10][2] = {{1, 2}, {3, 4}};
  {
    int arr[2][3] = {{5, 6}, {7, 8}};
  }
  return 0;
}
```

Generated LLVM IR:

```llvm
; the outer one is here
@___extracted_main_arr = global [20 x i32] [i32 1, i32 2, i32 3, i32 4, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
; the inner one is here
@___extracted_main_arr = global [6 x i32] [i32 5, i32 6, i32 0, i32 7, i32 8, i32 0]
define i32 @main() {
_entry:
	%_glob___extracted_main_arr = getelementptr inbounds [20 x i32] , [20 x i32] * @___extracted_main_arr, i32 0, i32 0
	%_glob___extracted_main_arr = getelementptr inbounds [6 x i32] , [6 x i32] * @___extracted_main_arr, i32 0, i32 0
	br label %_0
_0: ; preds = 
	ret i32 0
}
```

## Initial Value Evaluation on Global Variables (8fc5ea7)

TrivialCompiler will not evaluate initial values of all non-constant global variables, so the following C program will produce an incorrect result:

```c
// -1 will be parsed as (0-1)
int a = -1;

int main() {
  return a;
}
```

Generated LLVM IR:

```llvm
; it should be -1 but not zero
@_a = global i32 0
define i32 @main() {
_entry:
	%_glob_a = getelementptr inbounds i32 , i32 * @_a, i32 0
	br label %_0
_0: ; preds = 
	; gvn_gcm produced an incorrect result due to the evaluation error
	ret i32 0
}
```

According to the SysY language specification ([2020 ver.](https://gitlab.eduxiji.net/nscscc/docs/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf), [2021 ver.](https://gitlab.eduxiji.net/nscscc/compiler2021/-/blob/master/SysY%E8%AF%AD%E8%A8%80%E5%AE%9A%E4%B9%89.pdf)), section “初值.1”, initial expressions in all global variables should be constant expressions, so the modification in commit 8fc5ea7 makes sense.