### PR TITLE
Fixed an issue about calculating dominance trees in pass `mem2reg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Errata: the `.bc` should be `.ll` in the picture.
 
 ```bash
 mkdir build
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug # use Release for better performance, Debug for enabling ASan
 make -j
 ./TrivialCompiler -h # show usage

--- a/src/passes/ir/mem2reg.cpp
+++ b/src/passes/ir/mem2reg.cpp
@@ -4,10 +4,13 @@
 #include <unordered_map>
 
 #include "../../structure/ast.hpp"
+#include "bbopt.hpp"
 #include "cfg.hpp"
 
 // 这里假定dom树已经造好了
 void mem2reg(IrFunc *f) {
+  // 删除所有不可达bb，以防计算dom时出现问题
+  bbopt(f);
   compute_dom_info(f);
   std::unordered_map<Value *, u32> alloca_ids;  // 把alloca映射到整数，后面有好几个vector用这个做下标
   std::vector<Value *> allocas;


### PR DESCRIPTION
TrivialCompiler will crash when compiling the following C code:

```c
int main() {
  if (0) {
    if (0) {
      return 0;
    } else if (0) {
      return 0;
    } else if (0) {
      return 0;
    } else {
      return 0;
    }
  }
  return 0;
}
```

Because `convert_ssa` function will generate `main` as the following CFG:

![CFG of main](https://user-images.githubusercontent.com/5129820/129446727-56fe3f30-ab83-4cd3-a7d4-9381807cfd4c.png)

where BB 12, 9 and 6 are unreachable. The code to generate them is in [`ssa.cpp:214`](https://github.com/TrivialCompiler/TrivialCompiler/blob/8530458110e41b90e857aac3adc24a1f8db7d295/src/conv/ssa.cpp#L214).

This causes the `compute_dom_info` function to produce the wrong result, which in turn causes the `compute_df` function to access an uninitialized pointer.

To avoid this problem, this PR adds code to remove unreachable BBs before the initial call to the `compute_dom_info` function (in `mem2reg.cpp`).